### PR TITLE
Add support for individual field search

### DIFF
--- a/src/Controller/DataTablesAjaxRequestTrait.php
+++ b/src/Controller/DataTablesAjaxRequestTrait.php
@@ -66,6 +66,7 @@ trait DataTablesAjaxRequestTrait
         $this->viewBuilder()->className('DataTables.DataTables');
         $this->viewBuilder()->template(Inflector::underscore($configName));
 
+        // searching all fields
         $where = [];
         if (!empty($params['search']['value'])) {
             foreach ($config['columns'] as $column) {
@@ -95,6 +96,27 @@ trait DataTablesAjaxRequestTrait
                             break;
                     }
                 }
+            }
+        }
+
+        // searching individual field
+        foreach ($params['columns'] as $paramColumn) {
+            $columnSearch = $paramColumn['search']['value'];
+            if (!$columnSearch || !$paramColumn['searchable']) {
+                continue;
+            }
+
+            $operator = '';
+            $columnType = $config['columns'][$paramColumn['name']]['type'];
+
+            switch ($columnType) {
+                case 'text':
+                    $operator = ' LIKE';
+                    if (strpos($columnSearch, '%') === false) {
+                        $columnSearch = '%' . $columnSearch . '%';
+                    }
+                    $where[] = [$paramColumn['name'] . $operator => $columnSearch];
+                break;
             }
         }
 


### PR DESCRIPTION
For example, you can now do the following:

    $('#dtFoo').DataTable().columns(0).search('hello').draw()

which will generate the following where clause:

    WHERE Foo.column0 LIKE '%hello%'