### PR TITLE
Fix search and avoid invalid types

### DIFF
--- a/src/Controller/Component/DataTablesConfigComponent.php
+++ b/src/Controller/Component/DataTablesConfigComponent.php
@@ -107,7 +107,7 @@ class DataTablesConfigComponent extends Component
             'orderable' => true,
             'className' => null,
             'orderDataType' => 'dom-text',
-            'type' => 'text',
+            'type' => 'string',
             'name' => $name,
             'visible' => true,
             'width' => null,

--- a/src/Controller/Component/DataTablesConfigComponent.php
+++ b/src/Controller/Component/DataTablesConfigComponent.php
@@ -166,4 +166,29 @@ class DataTablesConfigComponent extends Component
         return $this;
     }
 
+    /**
+     * Add a new type map
+     * @return $this
+     */
+    public function addType($newType, $map = null)
+    {
+        if (array_key_exists($newType, $this->typeMap)) {
+            throw new \InvalidArgumentException("$type is already mapped.");
+        }
+        if ($map && !in_array($map, array_values($this->typeMap))) {
+            throw new \InvalidArgumentException("$map is not a supported type");
+        }
+        $this->typeMap[$newType] = $map === null ? $newType : $map;
+        return $this;
+    }
+
+    /**
+     * Get list of supported type maps
+     * @return array
+     */
+    public function getTypeMap()
+    {
+        return $this->typeMap;
+    }
+
 }

--- a/src/Controller/Component/DataTablesConfigComponent.php
+++ b/src/Controller/Component/DataTablesConfigComponent.php
@@ -22,6 +22,24 @@ class DataTablesConfigComponent extends Component
     private $currentConfig = null;
     private $defaultOptions = [];
 
+    /**
+     * Supported type maps
+     *
+     * See: https://datatables.net/reference/option/columns.type
+     */
+    private $typeMap = [
+        'date' => 'date',
+        'datetime' => 'date',
+        'num' => 'num',
+        'integer' => 'num',
+        'int' => 'num',
+        'num-fmt' => 'num-fmt',
+        'html-num-fmt' => 'html-num-fmt',
+        'html' => 'html',
+        'string' => 'string',
+        'text' => 'string',
+    ];
+
     public function initialize(array $config)
     {
         $this->dataTableConfig = &$config['DataTablesConfig'];
@@ -103,6 +121,10 @@ class DataTablesConfigComponent extends Component
             $options['searchable'] = false;
         }
 
+        if (!array_key_exists($options['type'], $this->typeMap)) {
+            throw new \InvalidArgumentException($options['type'] . ' is not a supported type');
+        }
+        $options['type'] = $this->typeMap[$options['type']];
 
         $this->dataTableConfig[$this->currentConfig]['columns'][$name] = $options;
         $this->dataTableConfig[$this->currentConfig]['columnsIndex'][] = $name;

--- a/src/Controller/DataTablesAjaxRequestTrait.php
+++ b/src/Controller/DataTablesAjaxRequestTrait.php
@@ -110,7 +110,7 @@ trait DataTablesAjaxRequestTrait
             $columnType = $config['columns'][$paramColumn['name']]['type'];
 
             switch ($columnType) {
-                case 'text':
+                case 'string':
                     $operator = ' LIKE';
                     if (strpos($columnSearch, '%') === false) {
                         $columnSearch = '%' . $columnSearch . '%';

--- a/src/Controller/DataTablesAjaxRequestTrait.php
+++ b/src/Controller/DataTablesAjaxRequestTrait.php
@@ -117,6 +117,10 @@ trait DataTablesAjaxRequestTrait
                     }
                     $where[] = [$paramColumn['name'] . $operator => $columnSearch];
                 break;
+
+                default:
+                    $where[] = ["{$paramColumn['name']} like" => "%{$columnSearch}%"];
+                break;
             }
         }
 


### PR DESCRIPTION
The first commit addresses the missing `default` in `switch`.

The other the commits addresses an issue where column type can be arbitrary and cause invalid values being checked in the `switch`.  For example, the default column type is `text`; while in the `DataTablesAjaxRequestTrait` we check against `string`.