### PR TITLE
Trait conflicts

### DIFF
--- a/src/Controller/Component/DataTablesConfigComponent.php
+++ b/src/Controller/Component/DataTablesConfigComponent.php
@@ -40,6 +40,11 @@ class DataTablesConfigComponent extends Component
         'text' => 'string',
     ];
 
+    private $supportedTraits = [
+        'DataTables\Controller\DataTablesAjaxRequestTrait',
+        'DataTables\Controller\FocSearchRequestTrait',
+    ];
+
     public function initialize(array $config)
     {
         $this->dataTableConfig = &$config['DataTablesConfig'];
@@ -61,6 +66,29 @@ class DataTablesConfigComponent extends Component
         $this->dataTableConfig[$name]['queryOptions'] = [];
         $this->dataTableConfig[$name]['options'] = $this->defaultOptions;
         $this->dataTableConfig[$name]['finder'] = "all";
+        $this->dataTableConfig[$name]['trait'] = "DataTablesAjaxRequestTrait";
+        $urls = [];
+        $controller = $this->getController();
+        foreach (class_uses($controller) as $trait) {
+            if (!in_array($trait, $this->supportedTraits)) {
+                continue;
+            }
+            switch ($trait) {
+                case 'DataTables\Controller\DataTablesAjaxRequestTrait':
+                    $urls['DataTablesAjaxRequestTrait'] = [
+                        'controller' => $controller->name,
+                        'action' => 'getDataTablesContent',
+                    ];
+                break;
+                case 'DataTables\Controller\FocSearchRequestTrait':
+                    $urls['FocSearchRequestTrait'] = [
+                        'controller' => $controller->name,
+                        'action' => 'getFocSearchDataTablesContent',
+                    ];
+                break;
+            }
+        }
+        $this->dataTableConfig[$name]['urls'] = $urls;
         return $this;
     }
 
@@ -203,6 +231,24 @@ class DataTablesConfigComponent extends Component
     public function getTypeMap()
     {
         return $this->typeMap;
+    }
+
+    /**
+     * Sets the trait to use for this table
+     * @param string $name Trait name to use
+     * @return $this
+     */
+    public function setTrait($name)
+    {
+        $supportedTraits = array_map(function($val) {
+            return array_pop(explode('\\', $val));
+        }, $this->supportedTraits);
+        if (!in_array($name, $supportedTraits)) {
+            throw new \InvalidArgumentException($name . ' is not a supported trait');
+        }
+        $this->dataTableConfig[$this->currentConfig]['trait'] = $name;
+
+        return $this;
     }
 
 }

--- a/src/Controller/Component/DataTablesConfigComponent.php
+++ b/src/Controller/Component/DataTablesConfigComponent.php
@@ -241,7 +241,8 @@ class DataTablesConfigComponent extends Component
     public function setTrait($name)
     {
         $supportedTraits = array_map(function($val) {
-            return array_pop(explode('\\', $val));
+            $vals = explode('\\', $val);
+            return array_pop($vals);
         }, $this->supportedTraits);
         if (!in_array($name, $supportedTraits)) {
             throw new \InvalidArgumentException($name . ' is not a supported trait');

--- a/src/Controller/FocSearchRequestTrait.php
+++ b/src/Controller/FocSearchRequestTrait.php
@@ -22,45 +22,45 @@ trait FocSearchRequestTrait
     /**
      * @var callable
      */
-    private $dataTableBeforeAjaxFunction = null;
+    private $focSearchDataTableBeforeAjaxFunction = null;
 
     /**
      * @var callable
      */
-    private $dataTableAfterAjaxFunction = null;
+    private $focSearchDataTableAfterAjaxFunction = null;
 
     /**
      * Set a function to be exec before ajax request
      * @param callable $dataTableBeforeAjaxFunction
      */
-    public function setDataTableBeforeAjaxFunction(callable $dataTableBeforeAjaxFunction)
+    public function setFocSearchDataTableBeforeAjaxFunction(callable $dataTableBeforeAjaxFunction)
     {
-        if (!is_callable($dataTableBeforeAjaxFunction)) {
+        if (!is_callable($focSearchDataTableBeforeAjaxFunction)) {
             throw new FatalErrorException(__d("datatables", "the parameter must be a function"));
         }
-        $this->dataTableBeforeAjaxFunction = $dataTableBeforeAjaxFunction;
+        $this->focSearchDataTableBeforeAjaxFunction = $dataTableBeforeAjaxFunction;
     }
 
     /**
      * Set a function to be exec after ajax request
      * @param callable $dataTableAfterAjaxFunction
      */
-    public function setDataTableAfterAjaxFunction(callable $dataTableAfterAjaxFunction)
+    public function setFocSearchDataTableAfterAjaxFunction(callable $dataTableAfterAjaxFunction)
     {
         if (!is_callable($dataTableAfterAjaxFunction)) {
             throw new FatalErrorException(__d("datatables", "the parameter must be a function"));
         }
-        $this->dataTableAfterAjaxFunction = $dataTableAfterAjaxFunction;
+        $this->focSearchDataTableAfterAjaxFunction = $dataTableAfterAjaxFunction;
     }
 
     /**
      * Ajax method to get data dynamically to the DataTables
      * @param string $config
      */
-    public function getDataTablesContent($config)
+    public function getFocSearchDataTablesContent($config)
     {
-        if (!empty($this->dataTableBeforeAjaxFunction) and is_callable($this->dataTableBeforeAjaxFunction)) {
-            call_user_func($this->dataTableBeforeAjaxFunction);
+        if (!empty($this->focSearchDataTableBeforeAjaxFunction) and is_callable($this->focSearchDataTableBeforeAjaxFunction)) {
+            call_user_func($this->focSearchDataTableBeforeAjaxFunction);
         }
 
         $this->request->allowMethod('ajax');
@@ -125,8 +125,8 @@ trait FocSearchRequestTrait
             'resultInfo' => $resultInfo,
         ]);
 
-        if (!empty($this->dataTableAfterAjaxFunction) and is_callable($this->dataTableAfterAjaxFunction)) {
-            call_user_func($this->dataTableAfterAjaxFunction);
+        if (!empty($this->focSearchDataTableAfterAjaxFunction) and is_callable($this->focSearchDataTableAfterAjaxFunction)) {
+            call_user_func($this->focSearchDataTableAfterAjaxFunction);
         }
     }
 

--- a/src/View/Helper/DataTablesHelper.php
+++ b/src/View/Helper/DataTablesHelper.php
@@ -134,7 +134,8 @@ class DataTablesHelper extends Helper
                 $options['processing'] = true;
                 $options['serverSide'] = true;
                 if (empty($options['ajax']['url'])) {
-                    $options['ajax']['url'] = Router::url(['controller' => $this->request->getParam('controller'), 'action' => 'getDataTablesContent', $item]);
+                    $url = $config['urls'][$config['trait']] + [$item];
+                    $options['ajax']['url'] = Router::url($url);
                 }
                 if (!empty($options['ajax']['error'])) {
                     $functionCode = $this->minifyJs($options['ajax']['error']);

--- a/src/View/Helper/DataTablesHelper.php
+++ b/src/View/Helper/DataTablesHelper.php
@@ -135,6 +135,9 @@ class DataTablesHelper extends Helper
                 $options['serverSide'] = true;
                 if (empty($options['ajax']['url'])) {
                     $url = $config['urls'][$config['trait']] + [$item];
+                    if ($config['trait'] === 'FocSearchRequestTrait') {
+                        $url = array_merge($url, $this->request->query);
+                    }
                     $options['ajax']['url'] = Router::url($url);
                 }
                 if (!empty($options['ajax']['error'])) {

--- a/src/View/Helper/DataTablesHelper.php
+++ b/src/View/Helper/DataTablesHelper.php
@@ -134,6 +134,9 @@ class DataTablesHelper extends Helper
                 $options['processing'] = true;
                 $options['serverSide'] = true;
                 if (empty($options['ajax']['url'])) {
+                    if (!$config['urls'][$config['trait']]) {
+                        throw new FatalErrorException('Cannot find url configuration for ' . $config['trait'] . ' for DataTable ' . $item . '. Perhaps you have not called setTrait() in your DataTable configuration.');
+                    }
                     $url = $config['urls'][$config['trait']] + [$item];
                     if ($config['trait'] === 'FocSearchRequestTrait') {
                         $url = array_merge($url, $this->request->query);


### PR DESCRIPTION
In some cases, you might need a controller to use both the default DataTables search method for one action with another action uses a `friendsofcake/search` search style.

This fixes the method name conflicts.

Configuring DataTablesComponent:

```php

  // Controller::initialize()
  public function initialize()
  {
    $this->DataTables->createConfig('yourDatatableWithFocSearch')
      ->setTrait('FocSearchRequestTrait')
      ->column([]) // set up your columns ...

    $this->DataTables->createConfig('yourDatatableWithDefaultAjaxRequestTrait')
      ->setTrait('DataTablesAjaxRequestTrait') // optional, this is used by default
      ->column([]) // set up your columns ...
  }
  
```

Unfortunately this adds some coupling between the traits, `DataTablesConfigComponent` and `DataTablesHelper`.

Closes #10 
